### PR TITLE
Fix jqwik Spring context setup

### DIFF
--- a/src/test/java/com/app/account/AccountApiPropertyTest.java
+++ b/src/test/java/com/app/account/AccountApiPropertyTest.java
@@ -1,5 +1,7 @@
 package com.app.account;
 
+import com.app.AppApplication;
+import com.app.account.AccountRepository;
 import com.app.account.dto.CreateAccountRequest;
 import com.app.account.dto.TransferRequest;
 import com.app.idempotency.IdempotencyRecordRepository;
@@ -16,42 +18,64 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Label;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import net.jqwik.api.lifecycle.AfterContainer;
+import net.jqwik.api.lifecycle.BeforeContainer;
 import net.jqwik.api.lifecycle.BeforeTry;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.TestInstance;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AccountApiPropertyTest {
 
-    @Autowired
+    private static ConfigurableApplicationContext context;
+
     private MockMvc mockMvc;
-
-    @Autowired
     private ObjectMapper objectMapper;
-
-    @Autowired
     private AccountRepository accountRepository;
-
-    @Autowired
     private AccountTransactionRepository transactionRepository;
-
-    @Autowired
     private IdempotencyRecordRepository idempotencyRecordRepository;
+
+    @BeforeContainer
+    void loadSpringContext() {
+        if (context == null) {
+            // Arrancamos la aplicación con el contexto completo y puerto aleatorio para reutilizar la pila web real.
+            context = new SpringApplicationBuilder(AppApplication.class)
+                    .properties(Map.of("server.port", "0"))
+                    .run();
+        }
+
+        // Obtenemos todos los beans necesarios para invocar la API desde MockMvc en cada propiedad.
+        objectMapper = context.getBean(ObjectMapper.class);
+        accountRepository = context.getBean(AccountRepository.class);
+        transactionRepository = context.getBean(AccountTransactionRepository.class);
+        idempotencyRecordRepository = context.getBean(IdempotencyRecordRepository.class);
+        WebApplicationContext webContext = (WebApplicationContext) context;
+        mockMvc = MockMvcBuilders.webAppContextSetup(webContext).build();
+    }
+
+    @AfterContainer
+    void closeSpringContext() {
+        if (context != null) {
+            // Liberamos los recursos asociados al contenedor web una vez finalicen todas las propiedades.
+            context.close();
+            context = null;
+        }
+    }
 
     @BeforeTry
     void cleanState() {
+        // Reiniciamos las tablas relevantes para que cada intento parta de un estado determinista.
         transactionRepository.deleteAll();
         idempotencyRecordRepository.deleteAll();
         accountRepository.deleteAll();
@@ -84,6 +108,7 @@ class AccountApiPropertyTest {
     void postThenGetMatchesState(@ForAll("accountNumbers") String accountNumber,
             @ForAll("holderNames") String holderName,
             @ForAll("balances") BigDecimal balance) throws Exception {
+        // Damos de alta la cuenta mediante la API REST y comprobamos que la lectura posterior refleja exactamente lo enviado.
         CreateAccountRequest request = new CreateAccountRequest();
         request.setAccountNumber(accountNumber);
         request.setHolderName(holderName);
@@ -109,6 +134,7 @@ class AccountApiPropertyTest {
     void transferKeepsReportedTotals(@ForAll("balances") BigDecimal sourceBalance,
             @ForAll("balances") BigDecimal targetBalance,
             @ForAll("transferAmounts") BigDecimal amount) throws Exception {
+        // Creamos dos cuentas vía HTTP y verificamos que cualquier transferencia conserva la suma de sus saldos visibles.
         String source = createAccountViaApi(sourceBalance);
         String target = createAccountViaApi(targetBalance);
 

--- a/src/test/java/com/app/account/AccountServicePropertyTest.java
+++ b/src/test/java/com/app/account/AccountServicePropertyTest.java
@@ -1,5 +1,6 @@
 package com.app.account;
 
+import com.app.AppApplication;
 import com.app.common.exception.BusinessException;
 import com.app.idempotency.IdempotencyRecordRepository;
 import com.app.transaction.AccountTransaction;
@@ -25,35 +26,54 @@ import net.jqwik.api.ForAll;
 import net.jqwik.api.Label;
 import net.jqwik.api.Property;
 import net.jqwik.api.Provide;
+import net.jqwik.api.lifecycle.AfterContainer;
+import net.jqwik.api.lifecycle.BeforeContainer;
 import net.jqwik.api.lifecycle.BeforeTry;
 import net.jqwik.api.statistics.Statistics;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.TestInstance;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-
-@SpringBootTest
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class AccountServicePropertyTest {
 
     private static final AtomicInteger ACCOUNT_SEQUENCE = new AtomicInteger();
 
-    @Autowired
+    private static ConfigurableApplicationContext context;
+
     private AccountService accountService;
-
-    @Autowired
     private AccountRepository accountRepository;
-
-    @Autowired
     private AccountTransactionRepository transactionRepository;
-
-    @Autowired
     private IdempotencyRecordRepository idempotencyRecordRepository;
+
+    @BeforeContainer
+    void loadSpringContext() {
+        if (context == null) {
+            // Inicializamos la aplicación exactamente igual que en producción para reutilizar todos los beans reales.
+            context = new SpringApplicationBuilder(AppApplication.class)
+                    .properties(Map.of("server.port", "0"))
+                    .run();
+        }
+
+        // Recuperamos los beans necesarios a partir del contexto arrancado una sola vez para todo el conjunto de propiedades.
+        accountService = context.getBean(AccountService.class);
+        accountRepository = context.getBean(AccountRepository.class);
+        transactionRepository = context.getBean(AccountTransactionRepository.class);
+        idempotencyRecordRepository = context.getBean(IdempotencyRecordRepository.class);
+    }
+
+    @AfterContainer
+    void closeSpringContext() {
+        if (context != null) {
+            // Cerramos el contexto al finalizar todas las propiedades para liberar conexiones y limpiar la memoria.
+            context.close();
+            context = null;
+        }
+    }
 
     @BeforeTry
     void cleanState() {
+        // Eliminamos cualquier rastro de datos generado en pruebas anteriores antes de cada intento de propiedad.
         transactionRepository.deleteAll();
         idempotencyRecordRepository.deleteAll();
         accountRepository.deleteAll();
@@ -74,7 +94,8 @@ class AccountServicePropertyTest {
 
     @Provide
     Arbitrary<BigDecimal> variableScaleAmounts() {
-        return monetaryAmount(new BigDecimal("0.0001"), new BigDecimal("1000000"), 0, 6);
+        // Para cantidades con más precisión forzamos a que la escala mínima permita representar 0.0001 sin errores.
+        return monetaryAmount(new BigDecimal("0.0001"), new BigDecimal("1000000"), 4, 6);
     }
 
     @Provide
@@ -99,6 +120,7 @@ class AccountServicePropertyTest {
     @Label("1.1 Depósito aumenta saldo y nunca negativo")
     void depositAlwaysIncreasesBalance(@ForAll("nonNegativeBalances") BigDecimal initialBalance,
             @ForAll("positiveAmounts") BigDecimal deposit) {
+        // Creamos una cuenta de prueba y aplicamos un depósito para comprobar que el saldo solo puede crecer.
         Account account = accountService.createAccount(nextAccountNumber(), "Holder", initialBalance);
         Account afterDeposit = accountService.deposit(account.getAccountNumber(), deposit);
 
@@ -156,6 +178,7 @@ class AccountServicePropertyTest {
     void transferConservesTotal(@ForAll("nonNegativeBalances") BigDecimal sourceBalance,
             @ForAll("nonNegativeBalances") BigDecimal targetBalance,
             @ForAll("positiveAmounts") BigDecimal amount) {
+        // Se crean dos cuentas y se registra el saldo total para verificar que una transferencia no crea ni destruye dinero.
         Account source = accountService.createAccount(nextAccountNumber(), "Source", sourceBalance);
         Account target = accountService.createAccount(nextAccountNumber(), "Target", targetBalance);
 


### PR DESCRIPTION
## Summary
- bootstrap a Spring Boot application context manually for jqwik property suites so repositories and services are available in each property try
- add explanatory comments and deterministic data cleanup before each property execution, closing the context afterwards to free resources
- adjust the variable-scale monetary generator to avoid precision errors when jqwik samples very small decimal values

## Testing
- ./mvnw -q test *(fails: wrapper cannot download Maven distribution because external network access is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f4b91a0c832e8da85ce964589634